### PR TITLE
Readonly support

### DIFF
--- a/src/AuthorizerFactory.ts
+++ b/src/AuthorizerFactory.ts
@@ -3,9 +3,9 @@ import { SubjectAuthorizer } from './SubjectAuthorizer';
 
 export class AuthorizerFactory implements IAuthorizerFactory {
 
-   private _allRoles: RoleDefinition[];
+   private _allRoles: readonly RoleDefinition[];
 
-   public constructor(allRoles: RoleDefinition[]) {
+   public constructor(allRoles: readonly RoleDefinition[]) {
       this._allRoles = allRoles;
    }
 

--- a/src/SubjectAuthorizer.ts
+++ b/src/SubjectAuthorizer.ts
@@ -15,7 +15,7 @@ export class SubjectAuthorizer implements ISubjectAuthorizer {
 
    private _policies: { deny: PolicyWithID[]; allow: PolicyWithID[] } = { deny: [], allow: [] };
 
-   public constructor(allRoles: RoleDefinition[], claims: Claims, opts?: Partial<ISubjectAuthorizerOpts>) {
+   public constructor(allRoles: readonly RoleDefinition[], claims: Claims, opts?: Partial<ISubjectAuthorizerOpts>) {
       const policies = claims.roles
          .map((roleClaim) => {
             const role = allRoles.find((r) => { return r.roleID === roleClaim.roleID; });

--- a/src/fsaba-types.ts
+++ b/src/fsaba-types.ts
@@ -135,13 +135,13 @@ export interface Policy {
    /**
     * What action(s) are allowed or disallowed by this policy?
     */
-   actions: string[];
+   actions: readonly string[];
 
    /**
     * On which resource(s) does this policy grant (or deny) permission to perform those
     * actions?
     */
-   resources: string[];
+   resources: readonly string[];
 
    /**
     * Are there any conditions that must apply to the contextual data about the action for
@@ -180,7 +180,7 @@ export interface RoleDefinition {
    /**
     * The policies this role includes.
     */
-   policies: Policy[];
+   policies: readonly Policy[];
 }
 
 
@@ -224,7 +224,7 @@ export interface Claims {
     * Role claims grant a user access to roles, and are thus used to build the complete
     * policyset by which the user's permissions are evaluated.
     */
-   roles: RoleClaim[];
+   roles: readonly RoleClaim[];
 }
 
 /**

--- a/src/utils/is-allowed.ts
+++ b/src/utils/is-allowed.ts
@@ -2,7 +2,7 @@ import { IsAllowedOpts, Policy, PolicyWithID } from '..';
 import allConditionsSatisfied from './conditions-match';
 import stringMatchesPattern from './string-matches-pattern';
 
-export default function isAllowed(policies: { deny: PolicyWithID[]; allow: PolicyWithID[] }, action: string, resource: string, opts?: Partial<IsAllowedOpts>): boolean { // eslint-disable-line max-len
+export default function isAllowed(policies: { deny: readonly PolicyWithID[]; allow: readonly PolicyWithID[] }, action: string, resource: string, opts?: Partial<IsAllowedOpts>): boolean { // eslint-disable-line max-len
    const isDenied = policies.deny.reduce((memo, policy) => {
       return memo || policyMatches(policy, action, resource, opts);
    }, false);
@@ -22,7 +22,7 @@ function policyMatches(policy: Omit<Policy, 'effect'>, action: string, resource:
       && (opts?.ignoreConditions || allConditionsSatisfied(policy.conditions, opts?.context));
 }
 
-function stringMatchesAnyOfMultiplePatterns(patterns: string[], value: string): boolean {
+function stringMatchesAnyOfMultiplePatterns(patterns: readonly string[], value: string): boolean {
    return patterns.reduce((memo, pattern) => {
       return memo || stringMatchesPattern(pattern, value);
    }, false as boolean);


### PR DESCRIPTION
By adding `readonly` to arrays that are intended to be immutable, we enable any application using this library to pass read-only arrays to it.

The `allRoles` argument passed to `SubjectAuthorizer` and `AuthorizerFactory`, for instance, is likely read-only in the parent application to avoid unintentional mutation. The same is true for other places where arrays are passed in. By using the `readonly` keyword, we are enabling the developer to use read-only arrays with FSABA.