### PR TITLE
chore: update to webpack 5.68.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1066,9 +1066,9 @@
          "dev": true
       },
       "@types/eslint": {
-         "version": "7.28.0",
-         "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.28.0.tgz",
-         "integrity": "sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==",
+         "version": "8.4.1",
+         "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.1.tgz",
+         "integrity": "sha512-GE44+DNEyxxh2Kc6ro/VkIj+9ma0pO0bwv9+uHSyBrikYOHr8zYcdPvnBOp1aw8s+CjRvuSx7CyWqRrNFQ59mA==",
          "dev": true,
          "requires": {
             "@types/estree": "*",
@@ -1076,9 +1076,9 @@
          }
       },
       "@types/eslint-scope": {
-         "version": "3.7.1",
-         "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.1.tgz",
-         "integrity": "sha512-SCFeogqiptms4Fg29WpOTk5nHIzfpKCemSN63ksBQYKTcXoJEmJagV+DhVmbapZzY4/5YaOV1nZwrsU79fFm1g==",
+         "version": "3.7.3",
+         "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.3.tgz",
+         "integrity": "sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==",
          "dev": true,
          "requires": {
             "@types/eslint": "*",
@@ -1418,9 +1418,9 @@
          "dev": true
       },
       "acorn-import-assertions": {
-         "version": "1.7.6",
-         "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.7.6.tgz",
-         "integrity": "sha512-FlVvVFA1TX6l3lp8VjDnYYq7R1nyW6x3svAt4nDgrWQ9SBaSh9CnbwgSUTasgfNfOG5HlM1ehugCvM+hjo56LA==",
+         "version": "1.8.0",
+         "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
+         "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
          "dev": true
       },
       "acorn-jsx": {
@@ -2936,9 +2936,9 @@
          }
       },
       "es-module-lexer": {
-         "version": "0.7.1",
-         "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz",
-         "integrity": "sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==",
+         "version": "0.9.3",
+         "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
+         "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
          "dev": true
       },
       "es6-error": {
@@ -4712,9 +4712,9 @@
          }
       },
       "jest-worker": {
-         "version": "27.0.6",
-         "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.0.6.tgz",
-         "integrity": "sha512-qupxcj/dRuA3xHPMUd40gr2EaAurFbkwzOh7wfPaeE9id7hyjURRQoqNfHifHK3XjJU6YJJUQKILGUnwGPEOCA==",
+         "version": "27.5.1",
+         "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+         "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
          "dev": true,
          "requires": {
             "@types/node": "*",
@@ -7169,14 +7169,14 @@
          "dev": true
       },
       "terser": {
-         "version": "5.7.1",
-         "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
-         "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+         "version": "5.10.0",
+         "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
+         "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
          "dev": true,
          "requires": {
             "commander": "^2.20.0",
             "source-map": "~0.7.2",
-            "source-map-support": "~0.5.19"
+            "source-map-support": "~0.5.20"
          },
          "dependencies": {
             "source-map": {
@@ -7184,32 +7184,38 @@
                "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
                "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
                "dev": true
+            },
+            "source-map-support": {
+               "version": "0.5.21",
+               "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+               "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+               "dev": true,
+               "requires": {
+                  "buffer-from": "^1.0.0",
+                  "source-map": "^0.6.0"
+               },
+               "dependencies": {
+                  "source-map": {
+                     "version": "0.6.1",
+                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                     "dev": true
+                  }
+               }
             }
          }
       },
       "terser-webpack-plugin": {
-         "version": "5.1.4",
-         "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.1.4.tgz",
-         "integrity": "sha512-C2WkFwstHDhVEmsmlCxrXUtVklS+Ir1A7twrYzrDrQQOIMOaVAYykaoo/Aq1K0QRkMoY2hhvDQY1cm4jnIMFwA==",
+         "version": "5.3.1",
+         "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
+         "integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
          "dev": true,
          "requires": {
-            "jest-worker": "^27.0.2",
-            "p-limit": "^3.1.0",
-            "schema-utils": "^3.0.0",
+            "jest-worker": "^27.4.5",
+            "schema-utils": "^3.1.1",
             "serialize-javascript": "^6.0.0",
             "source-map": "^0.6.1",
-            "terser": "^5.7.0"
-         },
-         "dependencies": {
-            "p-limit": {
-               "version": "3.1.0",
-               "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-               "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-               "dev": true,
-               "requires": {
-                  "yocto-queue": "^0.1.0"
-               }
-            }
+            "terser": "^5.7.2"
          }
       },
       "test-exclude": {
@@ -7611,9 +7617,9 @@
          }
       },
       "watchpack": {
-         "version": "2.2.0",
-         "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.2.0.tgz",
-         "integrity": "sha512-up4YAn/XHgZHIxFBVCdlMiWDj6WaLKpwVeGQk2I5thdYxF/KmF0aaz6TfJZ/hfl1h/XlcDr7k1KH7ThDagpFaA==",
+         "version": "2.3.1",
+         "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.3.1.tgz",
+         "integrity": "sha512-x0t0JuydIo8qCNctdDrn1OzH/qDzk2+rdCOC3YzumZ42fiMqmQ7T3xQurykYMhYfHaPHTp4ZxAx2NfUo1K6QaA==",
          "dev": true,
          "requires": {
             "glob-to-regexp": "^0.4.1",
@@ -7621,9 +7627,9 @@
          }
       },
       "webpack": {
-         "version": "5.49.0",
-         "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.49.0.tgz",
-         "integrity": "sha512-XarsANVf28A7Q3KPxSnX80EkCcuOer5hTOEJWJNvbskOZ+EK3pobHarGHceyUZMxpsTHBHhlV7hiQyLZzGosYw==",
+         "version": "5.68.0",
+         "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.68.0.tgz",
+         "integrity": "sha512-zUcqaUO0772UuuW2bzaES2Zjlm/y3kRBQDVFVCge+s2Y8mwuUTdperGaAv65/NtRL/1zanpSJOq/MD8u61vo6g==",
          "dev": true,
          "requires": {
             "@types/eslint-scope": "^3.7.0",
@@ -7635,12 +7641,12 @@
             "acorn-import-assertions": "^1.7.6",
             "browserslist": "^4.14.5",
             "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.8.0",
-            "es-module-lexer": "^0.7.1",
+            "enhanced-resolve": "^5.8.3",
+            "es-module-lexer": "^0.9.0",
             "eslint-scope": "5.1.1",
             "events": "^3.2.0",
             "glob-to-regexp": "^0.4.1",
-            "graceful-fs": "^4.2.4",
+            "graceful-fs": "^4.2.9",
             "json-parse-better-errors": "^1.0.2",
             "loader-runner": "^4.2.0",
             "mime-types": "^2.1.27",
@@ -7648,14 +7654,30 @@
             "schema-utils": "^3.1.0",
             "tapable": "^2.1.1",
             "terser-webpack-plugin": "^5.1.3",
-            "watchpack": "^2.2.0",
-            "webpack-sources": "^3.2.0"
+            "watchpack": "^2.3.1",
+            "webpack-sources": "^3.2.3"
          },
          "dependencies": {
             "acorn": {
-               "version": "8.4.1",
-               "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
-               "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
+               "version": "8.7.0",
+               "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+               "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+               "dev": true
+            },
+            "enhanced-resolve": {
+               "version": "5.9.0",
+               "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.9.0.tgz",
+               "integrity": "sha512-weDYmzbBygL7HzGGS26M3hGQx68vehdEg6VUmqSOaFzXExFqlnKuSvsEJCVGQHScS8CQMbrAqftT+AzzHNt/YA==",
+               "dev": true,
+               "requires": {
+                  "graceful-fs": "^4.2.4",
+                  "tapable": "^2.2.0"
+               }
+            },
+            "graceful-fs": {
+               "version": "4.2.9",
+               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
+               "integrity": "sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==",
                "dev": true
             }
          }
@@ -7706,9 +7728,9 @@
          }
       },
       "webpack-sources": {
-         "version": "3.2.0",
-         "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.0.tgz",
-         "integrity": "sha512-fahN08Et7P9trej8xz/Z7eRu8ltyiygEo/hnRi9KqBUs80KeDcnf96ZJo++ewWd84fEf3xSX9bp4ZS9hbw0OBw==",
+         "version": "3.2.3",
+         "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+         "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
          "dev": true
       },
       "websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
       "ts-loader": "9.2.5",
       "ts-node": "10.1.0",
       "typescript": "4.3.5",
-      "webpack": "5.49.0",
+      "webpack": "5.68.0",
       "webpack-cli": "4.7.2"
    },
    "dependencies": {


### PR DESCRIPTION
Upgrading to latest minor rev of webpack fixes the issue with the build failing in Node 17.x and doesn't make any changes to the bundle.